### PR TITLE
journalctl reverted to -n option

### DIFF
--- a/comm_server/hello_server.sh
+++ b/comm_server/hello_server.sh
@@ -42,8 +42,8 @@ shopt -u extglob
 
 # Make Logs
 mkdir -p LOGS
-journalctl -eu hypernets-sequence --since="2days ago" --no-pager > LOGS/hypernets-sequence.log
-journalctl -eu hypernets-hello --since="2days ago" --no-pager > LOGS/hypernets-hello.log
+journalctl -eu hypernets-sequence -n 1500 --no-pager > LOGS/hypernets-sequence.log
+journalctl -eu hypernets-hello -n 150 --no-pager > LOGS/hypernets-hello.log
 
 # Update the datetime flag on the server
 echo "Touching $ipServer:$remoteDir/system_is_up"


### PR DESCRIPTION
The --since option is not working as expected and we would like to revert the changes.